### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ Support features:
 Snapshot
 ======
 
-###Support display models:
+### Support display models:
 
 ![Features](https://github.com/habzy/GridImagePicker/blob/master/snapshot/features.jpg)
 
-###View & pick images
+### View & pick images
 ![Picker](https://github.com/habzy/GridImagePicker/blob/master/snapshot/pick_gridview.jpg)
 
-###View & pick image in ViewPager
+### View & pick image in ViewPager
 ![ViewPager](https://github.com/habzy/GridImagePicker/blob/master/snapshot/pick_viewpager.jpg) ==> ![full screen](https://github.com/habzy/GridImagePicker/blob/master/snapshot/pick_viewpager_zoomout.jpg)
 
-###Animation when change page
+### Animation when change page
 ![Animate](https://github.com/habzy/GridImagePicker/blob/master/snapshot/change.jpg)
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
